### PR TITLE
Fix disk extension flag in bootloader

### DIFF
--- a/src/bootloader/stage1/main.asm
+++ b/src/bootloader/stage1/main.asm
@@ -165,7 +165,7 @@ check_disk_extended:
     jne .no_disk_extended
 
     ; Extended disk functions are present.
-    mov byte [disk_extended_present], 0
+    mov byte [disk_extended_present], 1
     jmp .after_disk_check
 
 .no_disk_extended:


### PR DESCRIPTION
## Summary
- fix `disk_extended_present` flag handling in stage1 bootloader

## Testing
- `cmake --build build` *(fails: `/workspace/aidos4/toolchain/bin/x86_64-elf-g++: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6875a16fb958832f840261360e3cd5ef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the detection of extended disk functions to accurately reflect their availability, ensuring proper behavior when extended disk support is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->