### PR TITLE
Fix memory.hpp includes

### DIFF
--- a/src/bootloader/stage2/memory.hpp
+++ b/src/bootloader/stage2/memory.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <stddef.h>
 #include <stdint.h>
 
 inline int memcmp(const void* ptr1, const void* ptr2, size_t num) {


### PR DESCRIPTION
## Summary
- include `<stddef.h>` in bootloader memory header so `size_t` is defined

## Testing
- `g++ -std=c++17 -ffreestanding -c src/bootloader/stage2/memory.cpp`
- `g++ -std=c++17 -ffreestanding -Isrc/bootloader/stage2 -c src/bootloader/stage2/elf.cpp`
- `g++ -std=c++17 -ffreestanding -Isrc/bootloader/stage2 -c src/bootloader/stage2/Main.cpp`
- `g++ -std=c++17 -ffreestanding -Isrc/bootloader/stage2 -c src/bootloader/stage2/dev/io/text/vga/vga.cpp`
- `g++ -std=c++17 -ffreestanding -Isrc/bootloader/stage2 -c src/bootloader/stage2/dev/io/fs/fat/fat12.cpp`
- `g++ -std=c++17 -ffreestanding -Isrc/kernel -c src/kernel/kernel.cpp`
- `g++ -std=c++17 -ffreestanding -Isrc/kernel -c src/kernel/memory.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6875a3e8ba60832f94f3b4200f0dbf84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal compatibility for memory-related functions. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->