### PR TITLE
Add kernel load physical address in boot info

### DIFF
--- a/src/bootloader/stage2/Main.cpp
+++ b/src/bootloader/stage2/Main.cpp
@@ -34,6 +34,7 @@ struct BootInfoExtended
 {
     uint8_t memoryMapIndex;
     uint64_t* PML4Address;
+    uint64_t kernelPhysicalBase;
 };
 
 #pragma pack(pop)
@@ -90,7 +91,9 @@ extern "C" void stage2_main() {
         while(true){}
     }
 
-    void* entry = (void*)readElf(fs, hello, kernelStart);
+    ElfInfo info = readElf(fs, hello, kernelStart);
+    bootInfoExtended.kernelPhysicalBase = info.phys_base;
+    void* entry = (void*)info.entry;
 
     stdio::printf(vga, "Stage 2 cpp loaded!");
 

--- a/src/bootloader/stage2/elf.hpp
+++ b/src/bootloader/stage2/elf.hpp
@@ -1,4 +1,9 @@
 #include <stdint.h>
 #include "dev/io/fs/fs.hpp"
 
-uint64_t readElf(FileSystem* fs, File* file, void* data);
+struct ElfInfo {
+    uint64_t entry;        // Entry point of the loaded ELF
+    uint64_t phys_base;    // Physical base address where the ELF was loaded
+};
+
+ElfInfo readElf(FileSystem* fs, File* file, void* data);

--- a/src/kernel/kernel.cpp
+++ b/src/kernel/kernel.cpp
@@ -28,6 +28,7 @@ struct BootInfoExtended
 {
     uint8_t memoryMapIndex;
     uint64_t* PML4Address;
+    uint64_t kernelPhysicalBase;
 };
 #pragma pack(pop)
 


### PR DESCRIPTION
## Summary
- extend `BootInfoExtended` to capture the kernel's physical load address
- export this information from the bootloader ELF loader
- adapt the kernel entry point structures for the new field

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_687722d7f500832f8f5feda6894f13cd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The bootloader now tracks and provides the physical base address of the loaded kernel, making this information available during kernel startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->