### PR TITLE
Add kernel offset support for paging

### DIFF
--- a/src/kernel/kernel.cpp
+++ b/src/kernel/kernel.cpp
@@ -40,7 +40,8 @@ extern "C" void main(BootInfo* bootInfo, BootInfoExtended* bootInfoExtended) {
     memcpy(&bootInfoStatic, bootInfo, sizeof(BootInfo));
     memcpy(&bootInfoExtendedStatic, bootInfoExtended, sizeof(BootInfoExtended));
 
-    setup_paging(bootInfoExtendedStatic.PML4Address);
+    uint64_t kernelOffset = KERNEL_BASE - bootInfoExtendedStatic.kernelPhysicalBase;
+    setup_paging(bootInfoExtendedStatic.PML4Address, kernelOffset);
 
     ACPI acpi = ACPI((uint32_t*)bootInfoStatic.rsdp_addr);
 

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -146,6 +146,9 @@ void setup_paging(uint64_t* PML4Address, uint64_t kernelOffset) {
 PageTable* get_or_create_table(PageTable* parent, uint16_t index) {
     if (!((*parent)[index] & PAGE_PRESENT)) {
         PageTable* new_table = (PageTable*)kmalloc(sizeof(PageTable), 4096);
+        if (!new_table) {
+            return nullptr;
+        }
         memset(new_table, 0, 4096);
         (*parent)[index] = ((uint64_t)new_table - KERNEL_OFFSET) | PAGE_PRESENT | PAGE_RW;
         return new_table;

--- a/src/kernel/memory.cpp
+++ b/src/kernel/memory.cpp
@@ -44,7 +44,7 @@ constexpr uint64_t PAGE_4K       = 0x1000;
 constexpr uint64_t PAGE_2M       = 0x200000;               
 constexpr uint64_t PAGE_1G       = 0x40000000;
 
-constexpr uint64_t KERNEL_BASE = 0xFFFF'8000'0000'0000ULL;
+uint64_t KERNEL_OFFSET = 0;
 uint64_t virt_to_phys(uint64_t vaddr, uint64_t* oldPML4);
 
 
@@ -93,7 +93,8 @@ uint64_t virt_to_phys(uint64_t vaddr, uint64_t* oldPML4)
     return (pe & ADDR_MASK) + page_off;
 }
 
-void setup_paging(uint64_t* PML4Address) {
+void setup_paging(uint64_t* PML4Address, uint64_t kernelOffset) {
+    KERNEL_OFFSET = kernelOffset;
     memcpy(&pml4, PML4Address, sizeof(PageTable));
 
     for(int i = 0; i < 256; i++) {
@@ -146,10 +147,10 @@ PageTable* get_or_create_table(PageTable* parent, uint16_t index) {
     if (!((*parent)[index] & PAGE_PRESENT)) {
         PageTable* new_table = (PageTable*)kmalloc(sizeof(PageTable), 4096);
         memset(new_table, 0, 4096);
-        (*parent)[index] = (uint64_t)new_table | PAGE_PRESENT | PAGE_RW;
+        (*parent)[index] = ((uint64_t)new_table - KERNEL_OFFSET) | PAGE_PRESENT | PAGE_RW;
         return new_table;
     } else {
-        return (PageTable*)((*parent)[index] & ~0xFFF);
+        return (PageTable*)(((*parent)[index] & ~0xFFF) + KERNEL_OFFSET);
     }
 }
 
@@ -191,7 +192,7 @@ PageTable* get_table_if_exists(PageTable* parent, uint16_t index) {
     if (!( (*parent)[index] & PAGE_PRESENT ))
         return nullptr;
 
-    return reinterpret_cast<PageTable*>((*parent)[index] & ~0xFFFULL);
+    return reinterpret_cast<PageTable*>(((*parent)[index] & ~0xFFFULL) + KERNEL_OFFSET);
 }
 
 inline void flush_tlb_single(uint64_t va) {

--- a/src/kernel/memory.hpp
+++ b/src/kernel/memory.hpp
@@ -69,8 +69,14 @@ using PageTable = uint64_t[512];
 
 extern "C" void load_cr3(uint64_t); ///< Assembly helper to load CR3
 
-/// Initialise paging using the provided PML4.
-void setup_paging(uint64_t* PML4Address);
+/// Virtual base where the kernel is mapped.
+constexpr uint64_t KERNEL_BASE = 0xFFFF'8000'0000'0000ULL;
+
+/// Offset between physical memory and the higher half mapping.
+extern uint64_t KERNEL_OFFSET;
+
+/// Initialise paging using the provided PML4 and higher half offset.
+void setup_paging(uint64_t* PML4Address, uint64_t kernelOffset);
 PageTable* get_or_create_table(PageTable* parent, uint16_t index);
 void map_4k(uint64_t virt, uint64_t phys, uint64_t count);
 void map_2m(uint64_t virt, uint64_t phys, uint64_t count);


### PR DESCRIPTION
## Summary
- allow specifying kernel offset when setting up paging
- track kernel higher-half offset for new mappings
- use offset when allocating paging structures

## Testing
- `cmake -S . -B build`
- `cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_687735b3a14c832fa99cd65b5f9d7176

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved paging setup to support a dynamic kernel address offset, enhancing flexibility in memory management.

* **Bug Fixes**
  * Address translation for page tables now correctly accounts for the kernel offset, ensuring accurate mapping between virtual and physical addresses.

* **Documentation**
  * Updated function comments to reflect the new paging setup parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->